### PR TITLE
Feature/cb detail modal

### DIFF
--- a/src/components/modals/ClaimbuildDetailModal.vue
+++ b/src/components/modals/ClaimbuildDetailModal.vue
@@ -1,0 +1,38 @@
+<template>
+  <dialog id="claimbuild_detail_modal" class="modal">
+    <div class="modal-box h-screen max-w-screen-2xl">
+      <!-- Ways to close the modal while clicking on cross and outside of it -->
+      <form method="dialog">
+        <button class="btn btn-circle btn-secondary absolute right-0 top-0">
+          ✕
+        </button>
+      </form>
+      <!-- Modal content -->
+      <div class="grid h-full grid-flow-col grid-cols-4">
+        <div class="col-span-3">{{ selectedClaimbuild }}</div>
+        <div class="col-span-1">
+          <LazyLoadedImage
+            :key="'https://ateettea.sirv.com/Applications/Roleplay/20Cent_Gandalf_is_the_lord_of_the_ring_realistic_volumetric_lig_fb68c12b-7194-4b08-816b-23a4cf406651.png'"
+            :inside-classes="'h-full w-max object-cover'"
+            :evil-alt="'test'"
+            :good-alt="'test'"
+            :evil-src="'https://ateettea.sirv.com/Applications/Roleplay/20Cent_Gandalf_is_the_lord_of_the_ring_realistic_volumetric_lig_fb68c12b-7194-4b08-816b-23a4cf406651.png'"
+            :good-src="'https://ateettea.sirv.com/Applications/Roleplay/20Cent_Gandalf_is_the_lord_of_the_ring_realistic_volumetric_lig_fb68c12b-7194-4b08-816b-23a4cf406651.png'"
+          />
+        </div>
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+import LazyLoadedImage from "@/components/images/LazyLoadedImage.vue";
+import { Claimbuild } from "@/ts/types/Claimbuild";
+
+defineProps({
+  selectedClaimbuild: {
+    type: Object as Claimbuild,
+    required: false,
+  },
+});
+</script>

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildDetailModal.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildDetailModal.vue
@@ -12,6 +12,7 @@
         <div class="col-span-3">
           {{ selectedClaimbuild }}
           <ClaimbuildTopInfo :selected-claimbuild="selectedClaimbuild" />
+          <ClaimbuildMiddleInfo :selected-claimbuild="selectedClaimbuild" />
         </div>
         <div class="col-span-1">
           <LazyLoadedImage
@@ -32,6 +33,7 @@
 import LazyLoadedImage from "@/components/images/LazyLoadedImage.vue";
 import { Claimbuild } from "@/ts/types/Claimbuild";
 import ClaimbuildTopInfo from "@/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue";
+import ClaimbuildMiddleInfo from "@/components/modals/ClaimbuildDetailModal/ClaimbuildMiddleInfo.vue";
 
 defineProps({
   selectedClaimbuild: {

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildDetailModal.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildDetailModal.vue
@@ -18,12 +18,31 @@
         </div>
         <div class="col-span-1">
           <LazyLoadedImage
-            :key="'https://ateettea.sirv.com/Applications/Roleplay/20Cent_Gandalf_is_the_lord_of_the_ring_realistic_volumetric_lig_fb68c12b-7194-4b08-816b-23a4cf406651.png'"
             :inside-classes="'h-full w-max object-cover'"
-            :evil-alt="'test'"
-            :good-alt="'test'"
-            :evil-src="'https://ateettea.sirv.com/Applications/Roleplay/20Cent_Gandalf_is_the_lord_of_the_ring_realistic_volumetric_lig_fb68c12b-7194-4b08-816b-23a4cf406651.png'"
-            :good-src="'https://ateettea.sirv.com/Applications/Roleplay/20Cent_Gandalf_is_the_lord_of_the_ring_realistic_volumetric_lig_fb68c12b-7194-4b08-816b-23a4cf406651.png'"
+            :evil-alt="
+              getClaimbuildTypeImageAlt(
+                selectedClaimbuild.claimBuildType,
+                selectedClaimbuild.faction,
+              )
+            "
+            :good-alt="
+              getClaimbuildTypeImageAlt(
+                selectedClaimbuild.claimBuildType,
+                selectedClaimbuild.faction,
+              )
+            "
+            :evil-src="
+              getClaimbuildTypeImage(
+                selectedClaimbuild.claimBuildType,
+                selectedClaimbuild.faction,
+              )
+            "
+            :good-src="
+              getClaimbuildTypeImage(
+                selectedClaimbuild.claimBuildType,
+                selectedClaimbuild.faction,
+              )
+            "
           />
         </div>
       </div>
@@ -37,6 +56,10 @@ import { Claimbuild } from "@/ts/types/Claimbuild";
 import ClaimbuildTopInfo from "@/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue";
 import ClaimbuildMiddleInfo from "@/components/modals/ClaimbuildDetailModal/ClaimbuildMiddleInfo.vue";
 import ClaimbuildModalAccordions from "@/components/modals/ClaimbuildDetailModal/ClaimbuildModalAccordions.vue";
+import {
+  getClaimbuildTypeImage,
+  getClaimbuildTypeImageAlt,
+} from "@/ts/ClaimbuildTypeImageEnum";
 
 defineProps({
   selectedClaimbuild: {

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildDetailModal.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildDetailModal.vue
@@ -8,8 +8,11 @@
         </button>
       </form>
       <!-- Modal content -->
-      <div class="grid h-full grid-flow-col grid-cols-4">
-        <div class="col-span-3">{{ selectedClaimbuild }}</div>
+      <div class="grid h-full grid-cols-4">
+        <div class="col-span-3">
+          {{ selectedClaimbuild }}
+          <ClaimbuildTopInfo :selected-claimbuild="selectedClaimbuild" />
+        </div>
         <div class="col-span-1">
           <LazyLoadedImage
             :key="'https://ateettea.sirv.com/Applications/Roleplay/20Cent_Gandalf_is_the_lord_of_the_ring_realistic_volumetric_lig_fb68c12b-7194-4b08-816b-23a4cf406651.png'"
@@ -28,11 +31,12 @@
 <script setup lang="ts">
 import LazyLoadedImage from "@/components/images/LazyLoadedImage.vue";
 import { Claimbuild } from "@/ts/types/Claimbuild";
+import ClaimbuildTopInfo from "@/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue";
 
 defineProps({
   selectedClaimbuild: {
-    type: Object as Claimbuild,
-    required: false,
+    type: Object as () => Claimbuild,
+    required: true,
   },
 });
 </script>

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildDetailModal.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildDetailModal.vue
@@ -10,9 +10,11 @@
       <!-- Modal content -->
       <div class="grid h-full grid-cols-4">
         <div class="col-span-3">
-          {{ selectedClaimbuild }}
           <ClaimbuildTopInfo :selected-claimbuild="selectedClaimbuild" />
           <ClaimbuildMiddleInfo :selected-claimbuild="selectedClaimbuild" />
+          <ClaimbuildModalAccordions
+            :selected-claimbuild="selectedClaimbuild"
+          />
         </div>
         <div class="col-span-1">
           <LazyLoadedImage
@@ -34,6 +36,7 @@ import LazyLoadedImage from "@/components/images/LazyLoadedImage.vue";
 import { Claimbuild } from "@/ts/types/Claimbuild";
 import ClaimbuildTopInfo from "@/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue";
 import ClaimbuildMiddleInfo from "@/components/modals/ClaimbuildDetailModal/ClaimbuildMiddleInfo.vue";
+import ClaimbuildModalAccordions from "@/components/modals/ClaimbuildDetailModal/ClaimbuildModalAccordions.vue";
 
 defineProps({
   selectedClaimbuild: {

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildMiddleInfo.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildMiddleInfo.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="mx-10 grid grid-cols-2 grid-rows-2">
+    <div v-if="selectedClaimbuild.houses != 'none'">
+      <span class="text-accent">Houses: </span>
+      <span>{{ selectedClaimbuild.houses }}</span>
+    </div>
+    <div>
+      <span class="text-accent">Built by: </span>
+      <span>{{ builders }}</span>
+    </div>
+    <div v-if="selectedClaimbuild.traders != 'none'">
+      <span class="text-accent">Traders: </span>
+      <span>{{ selectedClaimbuild.traders }}</span>
+    </div>
+    <div v-if="selectedClaimbuild.siege != 'none'">
+      <span class="text-accent">Siege equipment: </span>
+      <span>{{ selectedClaimbuild.siege }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Claimbuild } from "@/ts/types/Claimbuild";
+import { computed, defineProps } from "vue";
+
+const props = defineProps({
+  selectedClaimbuild: {
+    type: Object as () => Claimbuild,
+    required: true,
+  },
+});
+
+// Get the ign from each builder and merge them into a string as a computed property
+const builders = computed(() => {
+  return props.selectedClaimbuild?.builtBy
+    .map((builder) => builder.ign)
+    .join(", ");
+});
+</script>

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildMiddleInfo.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildMiddleInfo.vue
@@ -21,7 +21,7 @@
 
 <script setup lang="ts">
 import { Claimbuild } from "@/ts/types/Claimbuild";
-import { computed, defineProps } from "vue";
+import { computed } from "vue";
 
 const props = defineProps({
   selectedClaimbuild: {

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildModalAccordions.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildModalAccordions.vue
@@ -9,7 +9,7 @@
       <div class="collapse-content">
         <p
           v-for="productionSite in selectedClaimbuild.productionSites"
-          :key="productionSite.productionSite"
+          :key="productionSite.productionSite.type"
         >
           {{ productionSite.amount }}
           {{ productionSite.productionSite.resource }}

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildModalAccordions.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildModalAccordions.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="m-6 grid grid-cols-2 gap-4">
+    <div
+      tabindex="0"
+      class="collapse-arrow collapse bg-base-300"
+      v-if="selectedClaimbuild.productionSites.length > 0"
+    >
+      <div class="collapse-title text-xl font-medium">Production Sites</div>
+      <div class="collapse-content">
+        <p
+          v-for="productionSite in selectedClaimbuild.productionSites"
+          :key="productionSite.productionSite"
+        >
+          {{ productionSite.amount }}
+          {{ productionSite.productionSite.resource }}
+          {{ productionSite.productionSite.type }}
+        </p>
+      </div>
+    </div>
+    <div
+      tabindex="0"
+      class="collapse-arrow collapse bg-base-300"
+      v-if="selectedClaimbuild.stationedArmies.length > 0"
+    >
+      <div class="collapse-title text-xl font-medium">Stationed Armies</div>
+      <div class="collapse-content">
+        <p
+          v-for="stationedArmy in selectedClaimbuild.stationedArmies"
+          :key="stationedArmy.name"
+        >
+          {{ stationedArmy.faction }} {{ stationedArmy.armyType }}:
+          {{ stationedArmy.name }}, bound to {{ stationedArmy.boundTo }}
+        </p>
+      </div>
+    </div>
+    <div
+      tabindex="0"
+      class="collapse-arrow collapse bg-base-300"
+      v-if="selectedClaimbuild.specialBuildings.length > 0"
+    >
+      <div class="collapse-title text-xl font-medium">Special Buildings</div>
+      <div class="collapse-content">
+        <p
+          v-for="specialBuilding in selectedClaimbuild.specialBuildings"
+          :key="specialBuilding"
+        >
+          {{ specialBuilding }}
+        </p>
+      </div>
+    </div>
+    <div
+      tabindex="0"
+      class="collapse-arrow collapse bg-base-300"
+      v-if="selectedClaimbuild.createdArmies.length > 0"
+    >
+      <div class="collapse-title text-xl font-medium">Created Armies</div>
+      <div class="collapse-content">
+        <p
+          v-for="stationedArmy in selectedClaimbuild.createdArmies"
+          :key="stationedArmy.name"
+        >
+          {{ stationedArmy.armyType }}: {{ stationedArmy.name }}, bound to
+          {{ stationedArmy.boundTo }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Claimbuild } from "@/ts/types/Claimbuild";
+
+defineProps({
+  selectedClaimbuild: {
+    type: Object as () => Claimbuild,
+    required: true,
+  },
+});
+</script>

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue
@@ -18,6 +18,32 @@
         </p>
       </div>
     </div>
+    <div class="card w-10/12 bg-base-300 shadow-xl">
+      <div class="card-body text-center">
+        <h2 class="card-title text-2xl font-bold">Location</h2>
+        <div class="divider"></div>
+        <div class="grid grid-cols-2 justify-items-stretch gap-y-4">
+          <p>Region:</p>
+          <p>{{ selectedClaimbuild.region }}</p>
+          <p>X:</p>
+          <p>{{ selectedClaimbuild.coordinates.x }}</p>
+          <p>Y:</p>
+          <p>{{ selectedClaimbuild.coordinates.y }}</p>
+        </div>
+      </div>
+    </div>
+    <div class="card w-10/12 bg-base-300 shadow-xl">
+      <div class="card-body text-center">
+        <h2 class="card-title text-2xl font-bold">Stationed</h2>
+        <div class="divider"></div>
+        <div class="grid grid-cols-2 justify-items-stretch gap-y-4">
+          <p>Armies:</p>
+          <p>{{ selectedClaimbuild.armiesStationedCount }}</p>
+          <p>Companies:</p>
+          <p>Coming soon</p>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue
@@ -16,6 +16,16 @@
           {{ selectedClaimbuild.claimBuildType }} -
           {{ selectedClaimbuild.faction }}
         </p>
+        <div class="mt-6">
+          <div>
+            <span class="text-accent">Free army slots: </span>
+            <span>{{ selectedClaimbuild.freeArmiesRemaining }}</span>
+          </div>
+          <div>
+            <span class="text-accent">Free company slots: </span>
+            <span>{{ selectedClaimbuild.freeCompaniesRemaining }}</span>
+          </div>
+        </div>
       </div>
     </div>
     <div class="card w-10/12 bg-base-300 shadow-xl">

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue
@@ -45,6 +45,7 @@
       </div>
     </div>
   </div>
+  <div class="divider mx-10"></div>
 </template>
 
 <script setup lang="ts">

--- a/src/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue
+++ b/src/components/modals/ClaimbuildDetailModal/ClaimbuildTopInfo.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="grid grid-cols-3">
+    <div class="flex flex-row justify-between">
+      <figure>
+        <img
+          class="mb-2 h-48 w-24"
+          :src="factionNameToBanner(selectedClaimbuild.faction)"
+          :alt="'alt'"
+        />
+      </figure>
+      <div class="mx-auto mt-6 flex flex-col items-center">
+        <h2 class="text-3xl font-bold text-accent">
+          {{ selectedClaimbuild.name }}
+        </h2>
+        <p class="text-2xl font-semibold text-primary">
+          {{ selectedClaimbuild.claimBuildType }} -
+          {{ selectedClaimbuild.faction }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { factionNameToBanner } from "@/ts/factionBannersEnum";
+import { Claimbuild } from "@/ts/types/Claimbuild";
+
+defineProps({
+  selectedClaimbuild: {
+    type: Object as () => Claimbuild,
+    required: true,
+  },
+});
+</script>

--- a/src/ts/ClaimbuildTypeImageEnum.ts
+++ b/src/ts/ClaimbuildTypeImageEnum.ts
@@ -1,0 +1,92 @@
+import { isFactionEvil } from "@/ts/utilities";
+
+export enum ClaimbuildTypeImageEnum {
+  GOOD_HAMLET = "https://ateettea.sirv.com/Claimbuild%20modal/good%20hamlet.png",
+  GOOD_VILLAGE = "https://ateettea.sirv.com/Claimbuild%20modal/good%20village.jpg",
+  GOOD_TOWN = "https://ateettea.sirv.com/Claimbuild%20modal/good%20town.png",
+  GOOD_CAPITAL = "https://ateettea.sirv.com/Claimbuild%20modal/good%20capital.jpg",
+  EVIL_HAMLET = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20hamlet.png",
+  EVIL_VILLAGE = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20village.png",
+  EVIL_TOWN = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20town.png",
+  EVIL_CAPITAL = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20capital.png",
+  GOOD_KEEP = "https://ateettea.sirv.com/Claimbuild%20modal/good%20keep.jpg",
+  GOOD_CASTLE = "https://ateettea.sirv.com/Claimbuild%20modal/good%20castle.png",
+  GOOD_STRONGHOLD = "https://ateettea.sirv.com/Claimbuild%20modal/good%20stronghold.png",
+  EVIL_KEEP = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20keep.jpg",
+  EVIL_CASTLE = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20castle.png",
+  EVIL_STRONGHOLD = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20stronghold.png",
+  GOOD_CAMP = "https://ateettea.sirv.com/Claimbuild%20modal/camp.jpg",
+  EVIL_CAMP = "https://ateettea.sirv.com/Claimbuild%20modal/camp.jpg",
+}
+
+export function getClaimbuildTypeImage(
+  claimbuildType: string,
+  factionName: string,
+): string {
+  claimbuildType = claimbuildType.toLowerCase();
+  const isEvil = isFactionEvil(factionName);
+  switch (claimbuildType) {
+    case "hamlet":
+      return isEvil
+        ? ClaimbuildTypeImageEnum.EVIL_HAMLET
+        : ClaimbuildTypeImageEnum.GOOD_HAMLET;
+    case "village":
+      return isEvil
+        ? ClaimbuildTypeImageEnum.EVIL_VILLAGE
+        : ClaimbuildTypeImageEnum.GOOD_VILLAGE;
+    case "town":
+      return isEvil
+        ? ClaimbuildTypeImageEnum.EVIL_TOWN
+        : ClaimbuildTypeImageEnum.GOOD_TOWN;
+    case "capital":
+      return isEvil
+        ? ClaimbuildTypeImageEnum.EVIL_CAPITAL
+        : ClaimbuildTypeImageEnum.GOOD_CAPITAL;
+    case "keep":
+      return isEvil
+        ? ClaimbuildTypeImageEnum.EVIL_KEEP
+        : ClaimbuildTypeImageEnum.GOOD_KEEP;
+    case "castle":
+      return isEvil
+        ? ClaimbuildTypeImageEnum.EVIL_CASTLE
+        : ClaimbuildTypeImageEnum.GOOD_CASTLE;
+    case "stronghold":
+      return isEvil
+        ? ClaimbuildTypeImageEnum.EVIL_STRONGHOLD
+        : ClaimbuildTypeImageEnum.GOOD_STRONGHOLD;
+    case "camp":
+      return isEvil
+        ? ClaimbuildTypeImageEnum.EVIL_CAMP
+        : ClaimbuildTypeImageEnum.GOOD_CAMP;
+    default:
+      return "";
+  }
+}
+
+export function getClaimbuildTypeImageAlt(
+  claimbuildType: string,
+  factionName: string,
+): string {
+  claimbuildType = claimbuildType.toLowerCase();
+  const isEvil = isFactionEvil(factionName);
+  switch (claimbuildType) {
+    case "hamlet":
+      return isEvil ? "Evil Hamlet" : "Good Hamlet";
+    case "village":
+      return isEvil ? "Evil Village" : "Good Village";
+    case "town":
+      return isEvil ? "Evil Town" : "Good Town";
+    case "capital":
+      return isEvil ? "Evil Capital" : "Good Capital";
+    case "keep":
+      return isEvil ? "Evil Keep" : "Good Keep";
+    case "castle":
+      return isEvil ? "Evil Castle" : "Good Castle";
+    case "stronghold":
+      return isEvil ? "Evil Stronghold" : "Good Stronghold";
+    case "camp":
+      return "Camp";
+    default:
+      return "";
+  }
+}

--- a/src/ts/ClaimbuildTypeImageEnum.ts
+++ b/src/ts/ClaimbuildTypeImageEnum.ts
@@ -1,21 +1,37 @@
 import { isFactionEvil } from "@/ts/utilities";
 
 export enum ClaimbuildTypeImageEnum {
+  // eslint-disable-next-line no-unused-vars
   GOOD_HAMLET = "https://ateettea.sirv.com/Claimbuild%20modal/good%20hamlet.png",
+  // eslint-disable-next-line no-unused-vars
   GOOD_VILLAGE = "https://ateettea.sirv.com/Claimbuild%20modal/good%20village.jpg",
+  // eslint-disable-next-line no-unused-vars
   GOOD_TOWN = "https://ateettea.sirv.com/Claimbuild%20modal/good%20town.png",
+  // eslint-disable-next-line no-unused-vars
   GOOD_CAPITAL = "https://ateettea.sirv.com/Claimbuild%20modal/good%20capital.jpg",
+  // eslint-disable-next-line no-unused-vars
   EVIL_HAMLET = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20hamlet.png",
+  // eslint-disable-next-line no-unused-vars
   EVIL_VILLAGE = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20village.png",
+  // eslint-disable-next-line no-unused-vars
   EVIL_TOWN = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20town.png",
+  // eslint-disable-next-line no-unused-vars
   EVIL_CAPITAL = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20capital.png",
+  // eslint-disable-next-line no-unused-vars
   GOOD_KEEP = "https://ateettea.sirv.com/Claimbuild%20modal/good%20keep.jpg",
+  // eslint-disable-next-line no-unused-vars
   GOOD_CASTLE = "https://ateettea.sirv.com/Claimbuild%20modal/good%20castle.png",
+  // eslint-disable-next-line no-unused-vars
   GOOD_STRONGHOLD = "https://ateettea.sirv.com/Claimbuild%20modal/good%20stronghold.png",
+  // eslint-disable-next-line no-unused-vars
   EVIL_KEEP = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20keep.jpg",
+  // eslint-disable-next-line no-unused-vars
   EVIL_CASTLE = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20castle.png",
+  // eslint-disable-next-line no-unused-vars
   EVIL_STRONGHOLD = "https://ateettea.sirv.com/Claimbuild%20modal/evil%20stronghold.png",
+  // eslint-disable-next-line no-unused-vars
   GOOD_CAMP = "https://ateettea.sirv.com/Claimbuild%20modal/camp.jpg",
+  // eslint-disable-next-line no-unused-vars
   EVIL_CAMP = "https://ateettea.sirv.com/Claimbuild%20modal/camp.jpg",
 }
 
@@ -23,9 +39,9 @@ export function getClaimbuildTypeImage(
   claimbuildType: string,
   factionName: string,
 ): string {
-  claimbuildType = claimbuildType.toLowerCase();
+  const lowercaseClaimbuildType = claimbuildType.toLowerCase();
   const isEvil = isFactionEvil(factionName);
-  switch (claimbuildType) {
+  switch (lowercaseClaimbuildType) {
     case "hamlet":
       return isEvil
         ? ClaimbuildTypeImageEnum.EVIL_HAMLET
@@ -67,9 +83,9 @@ export function getClaimbuildTypeImageAlt(
   claimbuildType: string,
   factionName: string,
 ): string {
-  claimbuildType = claimbuildType.toLowerCase();
+  const lowercaseClaimbuildType = claimbuildType.toLowerCase();
   const isEvil = isFactionEvil(factionName);
-  switch (claimbuildType) {
+  switch (lowercaseClaimbuildType) {
     case "hamlet":
       return isEvil ? "Evil Hamlet" : "Good Hamlet";
     case "village":

--- a/src/ts/types/Claimbuild.ts
+++ b/src/ts/types/Claimbuild.ts
@@ -5,6 +5,46 @@ export type Claimbuild = {
   claimBuildType: string;
   faction: string;
   armiesStationedCount: number;
+  siege: string;
+  houses: string;
+  coordinates: {
+    x: number;
+    y: number;
+    z: number;
+  };
+  traders: string;
+  builtBy: {
+    discordId: string;
+    ign: string;
+    faction: string;
+  }[];
+  specialBuildings: string[];
+  productionSites: {
+    amount: number;
+    productionSite: ProductionSite;
+  }[];
+  stationedArmies: {
+    id: number;
+    name: string;
+    armyType: string;
+    faction: string;
+    currentRegion: number;
+    boundTo: string;
+  }[];
+  createdArmies: {
+    id: number;
+    name: string;
+    armyType: string;
+    faction: string;
+    currentRegion: number;
+    boundTo: string;
+  }[];
+  freeArmiesRemaining: number;
+  createdArmyCount: number;
+  freeCompaniesRemaining: number;
+  createdCompaniesCount: number;
+  atMaxArmies: number;
+  atMaxCompanies: number;
 };
 
 export type ProductionSite = {

--- a/src/views/Dashboards/FactionDashboardComponents/FactionDashboardRegions.vue
+++ b/src/views/Dashboards/FactionDashboardComponents/FactionDashboardRegions.vue
@@ -103,7 +103,10 @@
       </div>
     </div>
   </div>
-  <ClaimbuildDetailModal :selected-claimbuild="selectedClaimbuild" />
+  <ClaimbuildDetailModal
+    v-if="selectedClaimbuild"
+    :selected-claimbuild="selectedClaimbuild"
+  />
 </template>
 
 <script setup lang="ts">
@@ -115,7 +118,7 @@ import SearchBar from "@/components/SearchBar.vue";
 import { RegionApiClient } from "@/ts/ApiService/RegionApiClient";
 import { ClaimbuildApiClient } from "@/ts/ApiService/ClaimbuildApiClient";
 import { Claimbuild } from "@/ts/types/Claimbuild";
-import ClaimbuildDetailModal from "@/components/modals/ClaimbuildDetailModal.vue";
+import ClaimbuildDetailModal from "@/components/modals/ClaimbuildDetailModal/ClaimbuildDetailModal.vue";
 
 const props = defineProps({
   faction: {

--- a/src/views/Dashboards/FactionDashboardComponents/FactionDashboardRegions.vue
+++ b/src/views/Dashboards/FactionDashboardComponents/FactionDashboardRegions.vue
@@ -88,12 +88,14 @@
                 </div>
               </td>
               <th>
-                <label
-                  for="rpCharDetailsModal"
+                <button
                   class="btn"
                   @click="sendInfoToModal(claimbuild)"
-                  >Details</label
+                  onclick="
+                  claimbuild_detail_modal.showModal()"
                 >
+                  Details
+                </button>
               </th>
             </tr>
           </tbody>
@@ -101,6 +103,7 @@
       </div>
     </div>
   </div>
+  <ClaimbuildDetailModal :selected-claimbuild="selectedClaimbuild" />
 </template>
 
 <script setup lang="ts">
@@ -112,6 +115,7 @@ import SearchBar from "@/components/SearchBar.vue";
 import { RegionApiClient } from "@/ts/ApiService/RegionApiClient";
 import { ClaimbuildApiClient } from "@/ts/ApiService/ClaimbuildApiClient";
 import { Claimbuild } from "@/ts/types/Claimbuild";
+import ClaimbuildDetailModal from "@/components/modals/ClaimbuildDetailModal.vue";
 
 const props = defineProps({
   faction: {
@@ -142,7 +146,7 @@ function showRegionDetails(region: Region) {
   showRegionClaimbuilds();
 }
 
-function sendInfoToModal(claimbuild: any) {
+function sendInfoToModal(claimbuild: Claimbuild) {
   selectedClaimbuild.value = claimbuild;
 }
 


### PR DESCRIPTION
The goal of this feature is to implement a modal which shows a very detailed view about all the data a claimbuild holds.

A basic design of this modal could look like this:

![image](https://github.com/Ardas-Legends-Development-Team/AL-frontend/assets/59698507/20552a89-1020-48fa-9ae6-b6afdf2367f0)

Features to do:

- [x] Create a big modal to add the elements
- [x] Fetch all data for the claimbuild
- [x] Add image to the right
- [x] Add faction banner, claimbuild name, type and controlling faction name
- [x] Add location info
- [x] Add stationed info
- [x] Add siege info (from workshop)
- [x] Add houses, traders and builders
- [x] Add collapsible tabs to add subsections
- [x] Add production site subsection
- [x] Add stationed armies subsection
- [x] Add special building subsection
- [x] Add created armies subsection


Details to do:

- [x] Show siege only if there are elements
- [x] Show empty slots for created armies if there are some left
- [x] Change image to the right depending on claimbuild type
