### PR TITLE
Bug/duplicate request fix

### DIFF
--- a/src/ts/ApiService/ApiClient.ts
+++ b/src/ts/ApiService/ApiClient.ts
@@ -23,6 +23,8 @@ axios.interceptors.response.use(
 );
 
 export abstract class ApiClient {
+  protected static pendingRequests: Map<string, Promise<any>> = new Map();
+
   private static baseUrl: string = `${
     import.meta.env.MODE === "production"
       ? config["backendUrl"]["production"]

--- a/src/ts/ApiService/ArmyApiClient.ts
+++ b/src/ts/ApiService/ArmyApiClient.ts
@@ -1,25 +1,51 @@
 import axios from "axios";
-
 import { Army } from "@/ts/types/Army";
 import { ApiClient } from "@/ts/ApiService/ApiClient";
 import { UnitType } from "@/ts/types/UnitType";
 
+// TODO: Connect them to the store
 export class ArmyApiClient extends ApiClient {
   public static async loadArmies(): Promise<Army[]> {
-    // TODO: connect to store
-    return new Promise((resolve) => {
-      axios.get(this.getBaseUrl() + "/army?size=1000").then((response) => {
-        resolve(response.data.content);
-      });
+    const requestKey = "loadArmies";
+
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<Army[]>((resolve) => {
+      axios
+        .get(this.getBaseUrl() + "/army?size=1000")
+        .then((response) => {
+          resolve(response.data.content);
+        })
+        .finally(() => {
+          this.pendingRequests.delete(requestKey);
+        });
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 
   public static async getAllAvailableUnitTypes(): Promise<UnitType[]> {
-    // TODO: connect to store
-    return new Promise((resolve) => {
-      axios.get(this.getBaseUrl() + "/unittypes").then((response) => {
-        resolve(response.data.content);
-      });
+    const requestKey = "getAllAvailableUnitTypes";
+
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<UnitType[]>((resolve) => {
+      axios
+        .get(this.getBaseUrl() + "/unittypes")
+        .then((response) => {
+          resolve(response.data.content);
+        })
+        .finally(() => {
+          this.pendingRequests.delete(requestKey);
+        });
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 }

--- a/src/ts/ApiService/ClaimbuildApiClient.ts
+++ b/src/ts/ApiService/ClaimbuildApiClient.ts
@@ -11,57 +11,112 @@ import { ApiClient } from "@/ts/ApiService/ApiClient";
 export class ClaimbuildApiClient extends ApiClient {
   public static async loadClaimbuildTypes(): Promise<string[]> {
     const claimbuildTypesStore = useClaimbuildTypeStore();
-    return new Promise((resolve) => {
+    const requestKey = "loadClaimbuildTypes";
+
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<string[]>((resolve) => {
       if (claimbuildTypesStore.claimbuildTypes.length > 0) {
         resolve(claimbuildTypesStore.claimbuildTypes);
         return;
       }
-      axios.get(this.getBaseUrl() + "/claimbuild/types").then((response) => {
-        claimbuildTypesStore.claimbuildTypes = response.data;
-        resolve(claimbuildTypesStore.claimbuildTypes);
-      });
+
+      axios
+        .get(this.getBaseUrl() + "/claimbuild/types")
+        .then((response) => {
+          claimbuildTypesStore.claimbuildTypes = response.data;
+          resolve(claimbuildTypesStore.claimbuildTypes);
+        })
+        .finally(() => {
+          this.pendingRequests.delete(requestKey);
+        });
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 
   public static async loadProductionSiteTypes(): Promise<ProductionSite[]> {
     const productionSiteTypeStore = useProductionSiteTypeStore();
-    return new Promise((resolve) => {
+    const requestKey = "loadProductionSiteTypes";
+
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<ProductionSite[]>((resolve) => {
       if (productionSiteTypeStore.productionSiteTypes.length > 0) {
         resolve(productionSiteTypeStore.productionSiteTypes);
         return;
       }
-      axios.get(this.getBaseUrl() + "/productionsite/all").then((response) => {
-        productionSiteTypeStore.productionSiteTypes = response.data;
-        resolve(productionSiteTypeStore.productionSiteTypes);
-      });
+
+      axios
+        .get(this.getBaseUrl() + "/productionsite/all")
+        .then((response) => {
+          productionSiteTypeStore.productionSiteTypes = response.data;
+          resolve(productionSiteTypeStore.productionSiteTypes);
+        })
+        .finally(() => {
+          this.pendingRequests.delete(requestKey);
+        });
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 
   public static async loadSpecialBuildingTypes(): Promise<string[]> {
     const specialBuildingStore = useSpecialBuildingStore();
-    return new Promise((resolve) => {
+    const requestKey = "loadSpecialBuildingTypes";
+
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<string[]>((resolve) => {
       if (specialBuildingStore.specialBuildings.length > 0) {
         resolve(specialBuildingStore.specialBuildings);
         return;
       }
+
       axios
         .get(this.getBaseUrl() + "/claimbuild/specialbuildings")
         .then((response) => {
           specialBuildingStore.specialBuildings = response.data;
           resolve(specialBuildingStore.specialBuildings);
+        })
+        .finally(() => {
+          this.pendingRequests.delete(requestKey);
         });
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 
   // TODO: connect to store
   public static async loadAllClaimbuilds(): Promise<Claimbuild[]> {
-    return new Promise((resolve) => {
+    const requestKey = "loadAllClaimbuilds";
+
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<Claimbuild[]>((resolve) => {
       axios
         .get(this.getBaseUrl() + "/claimbuild?size=1000")
         .then((response) => {
           resolve(response.data.content);
+        })
+        .finally(() => {
+          this.pendingRequests.delete(requestKey);
         });
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 
   public static async loadClaimbuildsByNames(
@@ -69,8 +124,13 @@ export class ClaimbuildApiClient extends ApiClient {
   ): Promise<Claimbuild[]> {
     // Retrieve the claimbuild store
     const claimbuildStore = useClaimbuildStore();
+    const requestKey = "loadClaimbuildsByNames";
 
-    return new Promise((resolve) => {
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<Claimbuild[]>((resolve) => {
       // Prepare arrays to hold claimbuilds that are already loaded and those to be fetched
       const alreadyLoadedCbs: Claimbuild[] = [];
       const cbsToFetch: string[] = [];
@@ -117,6 +177,9 @@ export class ClaimbuildApiClient extends ApiClient {
             // Resolve the promise with the already loaded claimbuilds
             resolve(alreadyLoadedCbs);
             return;
+          })
+          .finally(() => {
+            this.pendingRequests.delete(requestKey);
           });
       } else {
         // If no claimbuilds need to be fetched, resolve the promise with already loaded claimbuilds
@@ -124,18 +187,33 @@ export class ClaimbuildApiClient extends ApiClient {
         return;
       }
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 
   // TODO: connect to store
   public static async loadClaimbuildsByFaction(
     factionName: string,
   ): Promise<Claimbuild[]> {
-    return new Promise((resolve) => {
+    const requestKey = "loadClaimbuildsByFaction";
+
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<Claimbuild[]>((resolve) => {
       axios
         .get(this.getBaseUrl() + `/claimbuild/faction?faction=${factionName}`)
         .then((response) => {
           resolve(response.data);
+        })
+        .finally(() => {
+          this.pendingRequests.delete(requestKey);
         });
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 }

--- a/src/ts/ApiService/FactionApiClient.ts
+++ b/src/ts/ApiService/FactionApiClient.ts
@@ -59,7 +59,13 @@ export class FactionApiClient extends ApiClient {
 
   private static async loadFactionsDataIntoStore(): Promise<void> {
     const factionsStore = useFactionsStore();
-    return new Promise((resolve) => {
+    const requestKey = "loadFactionsDataIntoStore";
+
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<void>((resolve) => {
       axios
         .get(this.getBaseUrl() + "/faction", {
           params: {
@@ -81,7 +87,13 @@ export class FactionApiClient extends ApiClient {
             }
           });
           resolve();
+        })
+        .finally(() => {
+          this.pendingRequests.delete(requestKey);
         });
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 }

--- a/src/ts/ApiService/RegionApiClient.ts
+++ b/src/ts/ApiService/RegionApiClient.ts
@@ -6,31 +6,60 @@ import { ApiClient } from "@/ts/ApiService/ApiClient";
 export class RegionApiClient extends ApiClient {
   public static async loadRegionIds(): Promise<string[]> {
     const regionIdStore = useRegionIdStore();
-    return new Promise((resolve) => {
+    const requestKey = "loadRegionIds";
+
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<string[]>((resolve) => {
       if (regionIdStore.regionIds.length > 0) {
         resolve(regionIdStore.regionIds);
         return;
       }
-      axios.get(this.getBaseUrl() + "/region/all").then((response) => {
-        regionIdStore.regionIds = response.data.map(
-          (region: { id: string }) => region.id,
-        );
-        resolve(regionIdStore.regionIds);
-      });
+
+      axios
+        .get(this.getBaseUrl() + "/region/all")
+        .then((response) => {
+          regionIdStore.regionIds = response.data.map(
+            (region: { id: string }) => region.id,
+          );
+          resolve(regionIdStore.regionIds);
+        })
+        .finally(() => {
+          this.pendingRequests.delete(requestKey);
+        });
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 
   public static async loadRegions(): Promise<Region[]> {
     const regionStore = useRegionStore();
-    return new Promise((resolve) => {
+    const requestKey = "loadRegions";
+
+    if (this.pendingRequests.has(requestKey)) {
+      return this.pendingRequests.get(requestKey);
+    }
+
+    const request = new Promise<Region[]>((resolve) => {
       if (regionStore.regions.length > 0) {
         resolve(regionStore.regions);
         return;
       }
-      axios.get(this.getBaseUrl() + "/region/all/detailed").then((response) => {
-        regionStore.regions = response.data;
-        resolve(regionStore.regions);
-      });
+      axios
+        .get(this.getBaseUrl() + "/region/all/detailed")
+        .then((response) => {
+          regionStore.regions = response.data;
+          resolve(regionStore.regions);
+        })
+        .finally(() => {
+          this.pendingRequests.delete(requestKey);
+        });
     });
+
+    this.pendingRequests.set(requestKey, request);
+    return request;
   }
 }


### PR DESCRIPTION
Added a pending request Map which stores the requests that already have been sent. That way requests that come after it wait for the previous request to finish before continuing.

The positive side effect of this is that if the first one is successful and puts data into the store, the second request will just get the store's information.

closes #66 