### PR TITLE
Bug/no actions for rpchars

### DIFF
--- a/src/ts/ApiService/ArmyApiClient.ts
+++ b/src/ts/ApiService/ArmyApiClient.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import { Army } from "@/ts/types/Army";
 import { ApiClient } from "@/ts/ApiService/ApiClient";
 import { UnitType } from "@/ts/types/UnitType";
+import { usePlayerStore } from "@/stores/playerStores";
 
 // TODO: Connect them to the store
 export class ArmyApiClient extends ApiClient {
@@ -36,9 +37,13 @@ export class ArmyApiClient extends ApiClient {
 
     const request = new Promise<UnitType[]>((resolve) => {
       axios
-        .get(this.getBaseUrl() + "/unittypes")
+        .get(this.getBaseUrl() + "/unittypes", {
+          params: {
+            faction: [usePlayerStore().faction],
+          },
+        })
         .then((response) => {
-          resolve(response.data.content);
+          resolve(response.data);
         })
         .finally(() => {
           this.pendingRequests.delete(requestKey);

--- a/src/ts/ApiService/PlayerApiClient.ts
+++ b/src/ts/ApiService/PlayerApiClient.ts
@@ -80,7 +80,10 @@ export class PlayerApiClient extends ApiClient {
             characterStore.gear = data.rpChar.gear;
             characterStore.pvp = data.rpChar.pvp;
             characterStore.currentRegion = data.rpChar.currentRegion;
-            characterStore.boundTo = data.rpChar.boundTo;
+            characterStore.boundTo =
+              data.rpChar.boundTo === null
+                ? "Not bound to entity"
+                : data.rpChar.boundTo;
             characterStore.injured = data.rpChar.injured;
             characterStore.isHealing = data.rpChar.isHealing;
             characterStore.startedHeal = data.rpChar.startedHeal;

--- a/src/views/Dashboards/UserDashboardComponents/UserDashboardActions.vue
+++ b/src/views/Dashboards/UserDashboardComponents/UserDashboardActions.vue
@@ -30,7 +30,7 @@ import { useFactionsStore } from "@/stores/generalInfoStores";
 
 const shownCards: any = ref({});
 
-const playerHasRpChar = useCharacterStore.name === "No character name";
+const playerHasRpChar = useCharacterStore().name !== "No character name";
 
 const leaderActions = () => {
   shownCards.value.rankMove = rankCardData.leader.move;
@@ -44,9 +44,6 @@ const leaderActions = () => {
 
 const armyActions = () => {
   shownCards.value.memberUnbind = rankCardData.member.unbind;
-  // TODO: exclude the station/unstation actions if the player is already stationed when we get info from API
-  shownCards.value.memberStation = rankCardData.member.station;
-  shownCards.value.memberUnstation = rankCardData.member.unstation;
   shownCards.value.memberDeclareBattle = rankCardData.member.declareBattle;
 };
 
@@ -56,6 +53,13 @@ const rpCharActions = {
   },
   characterMove: () => {
     shownCards.value.memberMove = rankCardData.member.move;
+  },
+  // TODO: exclude the station/unstation actions if the player is already stationed when we get info from API
+  characterStation: () => {
+    shownCards.value.memberStation = rankCardData.member.station;
+  },
+  characterUnstation: () => {
+    shownCards.value.memberUnstation = rankCardData.member.unstation;
   },
 };
 
@@ -68,9 +72,9 @@ async function populateShownCards(rank: string): Promise<void> {
       }
       // Add all member actions concerning the player himself. Do not add mutually exclusive actions
       // Such as bind/unbind and station/unstation (they are mutually exclusive in the UI)
-      if (playerHasRpChar) {
-        rpCharActions.characterMove();
-      }
+      rpCharActions.characterMove();
+      rpCharActions.characterStation();
+      rpCharActions.characterUnstation();
       // If the player is not bound to an army, we only show the bind action and not unbind/station/unstation
       const isPlayerBound =
         (await getArmyBoundToPlayer(usePlayerStore().discordId)) !==


### PR DESCRIPTION
Fixed the unit types GET request in the Army API client to send the correct parameters and retrieve the correct field from the response.
Added missing actions for roleplay characters (move, station, unstation, bind).
Fixed a bug where receiving a null bound army was not handled. Now, if the bound army is null, it is set to "Not bound to entity".